### PR TITLE
ci: always collect flake logs for Windows repro

### DIFF
--- a/.github/workflows/repro-windows-integration-flake.yml
+++ b/.github/workflows/repro-windows-integration-flake.yml
@@ -24,13 +24,24 @@ jobs:
       - name: Run repeated e2e test runs
         run: |
           mkdir flake-logs
+          $failed = $false
           for ($i=1; $i -le 20; $i++) {
-            Write-Output "--- RUN $i ---" | Out-File -FilePath flake-logs/run_$i.txt -Encoding utf8
-            pytest tests/e2e -k preprod_infra -q 2>&1 | Tee-Object -FilePath flake-logs/run_$i.txt -Append
-            if ($LASTEXITCODE -ne 0) { Write-Output "FAILED with exit $LASTEXITCODE" | Out-File -FilePath flake-logs/run_$i.txt -Append; break }
+            $file = "flake-logs/run_$i.txt"
+            "--- RUN $i ---" | Out-File -FilePath $file -Encoding utf8
+            pytest tests/e2e -k preprod_infra -q 2>&1 | Tee-Object -FilePath $file -Append
+            if ($LASTEXITCODE -ne 0) { "FAILED with exit $LASTEXITCODE" | Out-File -FilePath $file -Append; $failed = $true; break }
           }
+          if (-not (Test-Path flake-logs/summary.txt)) { "runs_completed=$i; failed=$failed" | Out-File flake-logs/summary.txt -Encoding utf8 }
+          # always exit 0 so upload step runs and artifacts are collected
+          exit 0
+
+      - name: Ensure artifact present
+        run: |
+          if (-not (Test-Path flake-logs)) { mkdir flake-logs }
+          if (-not (Test-Path flake-logs/summary.txt)) { "no_runs_collected=true" | Out-File flake-logs/summary.txt -Encoding utf8 }
 
       - name: Upload logs
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: flake-logs


### PR DESCRIPTION
Ensure the Windows repro workflow always writes a summary and uploads the flake-logs artifact so logs are available for triage.