### PR TITLE
ci: install pytest in Windows repro workflow

### DIFF
--- a/.github/workflows/repro-windows-integration-flake.yml
+++ b/.github/workflows/repro-windows-integration-flake.yml
@@ -20,6 +20,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           if (Test-Path requirements.txt) { pip install -r requirements.txt }
+          # ensure pytest is available for test runs
+          python -m pip install pytest
 
       - name: Run repeated e2e test runs
         run: |


### PR DESCRIPTION
Install pytest explicitly so the Windows repro workflow can run tests (pytest not present by default).