### PR TITLE
ci: harden repro workflow with retries and logs

### DIFF
--- a/.github/workflows/repro-windows-integration-flake.yml
+++ b/.github/workflows/repro-windows-integration-flake.yml
@@ -19,9 +19,23 @@ jobs:
       - name: Install requirements
         run: |
           python -m pip install --upgrade pip
-          if (Test-Path requirements.txt) { pip install -r requirements.txt }
-          # ensure pytest is available for test runs
-          python -m pip install pytest
+          # install requirements with retries to avoid transient network/setup failures
+          if (Test-Path requirements.txt) {
+            $tries=0; $max=3; while ($tries -lt $max) {
+              try {
+                python -m pip install -r requirements.txt 2>&1 | Tee-Object -FilePath .\flake-logs\pip_install.txt -Append
+                break
+              } catch {
+                $tries++
+                Start-Sleep -Seconds (5 * $tries)
+                if ($tries -ge $max) { Write-Output "pip install failed after $max attempts"; exit 1 }
+              }
+            }
+          }
+          # ensure pytest is available for test runs (retry)
+          $tries=0; $max=3; while ($tries -lt $max) {
+            try { python -m pip install pytest 2>&1 | Tee-Object -FilePath .\flake-logs\pip_install.txt -Append; break } catch { $tries++; Start-Sleep -Seconds (5 * $tries); if ($tries -ge $max) { Write-Output "pytest install failed after $max attempts"; exit 1 } }
+          }
 
       - name: Run repeated e2e test runs
         run: |
@@ -36,8 +50,17 @@ jobs:
           for ($i=1; $i -le 20; $i++) {
             $file = "flake-logs/run_$i.txt"
             "--- RUN $i ---" | Out-File -FilePath $file -Encoding utf8
-            python -m pytest tests/e2e -k preprod_infra -q 2>&1 | Tee-Object -FilePath $file -Append
-            if ($LASTEXITCODE -ne 0) { "FAILED with exit $LASTEXITCODE" | Out-File -FilePath $file -Append; $failed = $true; break }
+            # attempt pytest up to 3 times per run to reduce transient failures
+            $attempt=0; $maxAttempt=3; $rc=1
+            while ($attempt -lt $maxAttempt) {
+              $attempt++
+              "[ATTEMPT] run=$i attempt=$attempt" | Out-File -FilePath $file -Append -Encoding utf8
+              python -m pytest tests/e2e -k preprod_infra -q 2>&1 | Tee-Object -FilePath $file -Append
+              $rc = $LASTEXITCODE
+              if ($rc -eq 0) { break }
+              Start-Sleep -Seconds (3 * $attempt)
+            }
+            if ($rc -ne 0) { "FAILED with exit $rc after $attempt attempts" | Out-File -FilePath $file -Append; $failed = $true; break }
           }
           if (-not (Test-Path flake-logs/summary.txt)) { "runs_completed=$i; failed=$failed" | Out-File flake-logs/summary.txt -Encoding utf8 }
           # always exit 0 so upload step runs and artifacts are collected


### PR DESCRIPTION
Adds pip install retries and per-run pytest retries to the repro Windows workflow, and records pip output to flake-logs for triage of transient runner/setup failures.