### PR TITLE
fix(ci): ensure pytest basetemp directory in workflows

### DIFF
--- a/.github/workflows/ci-e2e-preprod.yml
+++ b/.github/workflows/ci-e2e-preprod.yml
@@ -63,7 +63,9 @@ jobs:
           export RUN_E2E=1
           # ensure repo importable via .pth fallback
           if [ -f .github/scripts/write_pth.py ]; then python .github/scripts/write_pth.py; fi
-          python -m pytest -q -m e2e || true
+          # ensure pytest has a writable basetemp directory
+          mkdir -p ./.tmp/pytest
+          python -m pytest -q -m e2e --basetemp=./.tmp/pytest || true
 
       - name: Stop mock services
         if: always()

--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -34,7 +34,10 @@ jobs:
           # Prefer running tests that are not marked as E2E. Adjust marker as needed.
           # ensure repo importable via .pth fallback
           if [ -f .github/scripts/write_pth.py ]; then python .github/scripts/write_pth.py; fi
-          python -m pytest -q -m "not e2e" || true
+          # ensure pytest has a writable basetemp directory to avoid FileNotFoundError
+          mkdir -p ./.tmp/pytest
+          PYTEST_BASETMP=./.tmp/pytest
+          python -m pytest -q -m "not e2e" --basetemp="$PYTEST_BASETMP" || true
 name: CI — Integration Tests (simulated)
 
 on:
@@ -84,4 +87,6 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest -q
+          # ensure pytest has a writable basetemp directory to avoid FileNotFoundError
+          mkdir -p ./.tmp/pytest
+          pytest -q --basetemp=./.tmp/pytest


### PR DESCRIPTION
Creates ./.tmp/pytest and passes --basetemp to pytest in CI workflows to avoid FileNotFoundError during test runs.