### PR TITLE
ci: ensure pytest available in Token Cache CI

### DIFF
--- a/.github/workflows/token-cache.yml
+++ b/.github/workflows/token-cache.yml
@@ -20,9 +20,13 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt || true
+          pip install -r requirements-dev.txt || true
+      - name: Prepare pytest basetemp
+        run: |
+          python -c "import os; os.makedirs('.tmp/pytest', exist_ok=True)"
       - name: Run unit tests
         run: |
-          pytest -q
+          python -m pytest -q --basetemp .tmp/pytest
       - name: Start token-cache (smoke)
         run: |
           # In CI we will not keep long-running services; run a quick invocation of helper


### PR DESCRIPTION
Install equirements-dev.txt and run tests via python -m pytest in the Token Cache CI workflow so pytest is available in CI runs. This fixes failing 'pytest: command not found' errors observed after the recent history rewrite.\n\nWorkflow modified: .github/workflows/token-cache.yml