### PR TITLE
ci: avoid fetching LFS objects in workflows

### DIFF
--- a/.github/workflows/allowlist-tests.yml
+++ b/.github/workflows/allowlist-tests.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: false
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/auto-pr-with-tests.yml
+++ b/.github/workflows/auto-pr-with-tests.yml
@@ -16,6 +16,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          lfs: false
+        with:
           fetch-depth: 0
           lfs: true
 

--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -16,6 +16,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          lfs: false
+        with:
           fetch-depth: 0
           lfs: true
 

--- a/.github/workflows/auto-triage.yml
+++ b/.github/workflows/auto-triage.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          lfs: false
 
       - name: Install dependencies (gh, zip)
         run: |

--- a/.github/workflows/automerge-agent-dry-run.yml
+++ b/.github/workflows/automerge-agent-dry-run.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          lfs: false
+        with:
           lfs: true
 
       - name: Install Git LFS

--- a/.github/workflows/ci-e2e-preprod.yml
+++ b/.github/workflows/ci-e2e-preprod.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          lfs: false
+        with:
           lfs: true
 
       - name: Set up Python

--- a/.github/workflows/ci-fixed.yml
+++ b/.github/workflows/ci-fixed.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          lfs: false
+        with:
           fetch-depth: 0
           lfs: true
 

--- a/.github/workflows/token-cache.yml
+++ b/.github/workflows/token-cache.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: false
       - name: Set up Python
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
Temporarily set ctions/checkout with lfs: false in several workflows to avoid Git LFS quota failures in CI. This prevents CI from attempting to download LFS objects while maintainers resolve LFS billing or hosting.\n\nFiles modified: multiple workflows under .github/workflows/